### PR TITLE
separate helmfile cache for each app by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Of the above `ENV` variables, the following do variable expansion on the value:
 - `HELM_TEMPLATE_OPTIONS`
 - `HELMFILE_INIT_SCRIPT_FILE`
 - `HELM_DATA_HOME`
+- `HELM_CACHE_HOME`
+- `XDG_CACHE_HOME`
 
 Meaning, you can do things like:
 

--- a/src/argo-cd-helmfile.sh
+++ b/src/argo-cd-helmfile.sh
@@ -107,6 +107,20 @@ phase=$1
 export HELM_HOME="/tmp/__${SCRIPT_NAME}__/apps/${ARGOCD_APP_NAME}"
 export HELMFILE_HELMFILE_HELMFILED="${PWD}/.__${SCRIPT_NAME}__helmfile.d"
 
+# set helm cache dir explicitly so it does not use XDG_CACHE_HOME
+if [[ "${HELM_CACHE_HOME}" ]]; then
+  export HELM_CACHE_HOME=$(variable_expansion "${HELM_CACHE_HOME}")
+fi
+export HELM_CACHE_HOME="${HELM_CACHE_HOME:-/tmp/helm_cache}"
+
+# set up separate helmfile cache dir for each app (helmfile uses XDG_CACHE_HOME)
+# so helmfile cache cleanup on one app doesn't wipe out other apps while they are generating
+if [[ "${XDG_CACHE_HOME}" ]]; then
+  export XDG_CACHE_HOME=$(variable_expansion "${XDG_CACHE_HOME}")
+else
+  export XDG_CACHE_HOME="/tmp/helmfile_cache/${ARGOCD_APP_NAME}"
+fi
+
 if [[ ! -d "/tmp/__${SCRIPT_NAME}__/bin" ]]; then
   mkdir -p "/tmp/__${SCRIPT_NAME}__/bin"
 fi


### PR DESCRIPTION
Hello,

This PR is related to the helmfile cache cleanup option. If we have an argo-cd instance with multiple apps running helmfile cache cleanup, one of them might wipe out the cache for another, and to prevent this we should make it safe by default. I have also added a better helm cache configuration option, as by default helm and helmfile both use XDG_CACHE_HOME and maybe people don't want their helm cache path to be automatically changed.

Does this look OK to you? Or maybe it should be applied only when the HELMFILE_CACHE_CLEANUP option is activated, but it would make the code more complicated and it shouldn't affect very much and can be overridden.

Thanks!